### PR TITLE
Added installation instructions for RHEL-based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Required by what are currently the only modules:
 * [Websocket++](http://www.zaphoyd.com/websocketpp)
 
 Install everything (for Ubuntu):
-```bash
+```sh
 sudo apt install build-essential libboost-all-dev libssl-dev libcrypto++-dev libcurl4-openssl-dev libwebsocketpp-dev libcurlpp-dev
+```
+
+```sh
+sudo dnf install openssl-devel boost-devel cryptopp-devel cryptopp curlpp-devel websocketpp-devel cmake
 ```
 
 Included <sup>(Git submodules)</sup>

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Required by what are currently the only modules:
 * [Crypto++](https://www.cryptopp.com/)
 * [Websocket++](http://www.zaphoyd.com/websocketpp)
 
-Install everything (for Ubuntu):
+Install everything (Debian-based distros):
 ```sh
 sudo apt install build-essential libboost-all-dev libssl-dev libcrypto++-dev libcurl4-openssl-dev libwebsocketpp-dev libcurlpp-dev
 ```
-
+Install everything (Fedora/RHEL-based distros):
 ```sh
 sudo dnf install openssl-devel boost-devel cryptopp-devel cryptopp curlpp-devel websocketpp-devel cmake
 ```


### PR DESCRIPTION
Added code snippet to install all needed dependencies to build. Tested on fedora 27. Also changed ubuntu to debian because the snippet will work on all debian based distros. 

Not much else to say.