### PR TITLE
Add color to CLI output

### DIFF
--- a/discordpp/bot.hh
+++ b/discordpp/bot.hh
@@ -15,6 +15,8 @@
 #include "restmodule.hh"
 #include "websocketmodule.hh"
 
+#include "colors.hh"
+
 namespace discordpp {
     class Bot;
 
@@ -31,15 +33,15 @@ namespace discordpp {
                 rmod_(rmod),
                 wsmod_(wsmod) {
             handlers_.insert(std::pair<std::string, Handler>("READY", [this](Bot *bot, json jmessage) {
-                std::cout << "Recieved READY payload.\n";
-                std::cout << jmessage.dump(4) << "\n\n\n";
+                std::cout << color("Recieved READY payload.\n", Color.Green);
+                std::cout << color(jmessage.dump(4), Color.Italic) << "\n\n\n";
                 bot->gatewayVersion_ = jmessage["v"];
                 bot->me_ = jmessage["user"];
                 bot->guilds_ = jmessage["guilds"];
                 wsmod_->sessionID_ = jmessage["session_id"];
             }));
             Handler guildmod = [](Bot *bot, json jmessage) {
-                std::cout << "Recieved GUILD_CREATE payload.\n";
+                std::cout << color("Recieved GUILD_CREATE payload.\n", Color.Green);
                 //if(jmessage["s"].get<int>() == 4) {
                 //    jmessage.erase("d");
                 //}

--- a/discordpp/bot.hh
+++ b/discordpp/bot.hh
@@ -33,15 +33,15 @@ namespace discordpp {
                 rmod_(rmod),
                 wsmod_(wsmod) {
             handlers_.insert(std::pair<std::string, Handler>("READY", [this](Bot *bot, json jmessage) {
-                std::cout << color("Recieved READY payload.\n", Color.Green);
-                std::cout << color(jmessage.dump(4), Color.Italic) << "\n\n\n";
+                std::cout << color("Recieved READY payload.\n", Green);
+                std::cout << color(jmessage.dump(4), Italic) << "\n\n\n";
                 bot->gatewayVersion_ = jmessage["v"];
                 bot->me_ = jmessage["user"];
                 bot->guilds_ = jmessage["guilds"];
                 wsmod_->sessionID_ = jmessage["session_id"];
             }));
             Handler guildmod = [](Bot *bot, json jmessage) {
-                std::cout << color("Recieved GUILD_CREATE payload.\n", Color.Green);
+                std::cout << color("Recieved GUILD_CREATE payload.\n", Green);
                 //if(jmessage["s"].get<int>() == 4) {
                 //    jmessage.erase("d");
                 //}

--- a/discordpp/colors.hh
+++ b/discordpp/colors.hh
@@ -24,7 +24,7 @@ namespace discordpp
         White
     };
 
-    void color(std::string str, Color color)
+    std::string color(std::string str, Color color)
     {
         std::string clrstr = std::to_string(color);
         std::ostringstream clr;
@@ -34,9 +34,9 @@ namespace discordpp
             << "m"
             << str
             << "\033["
-            << Color.Reset
+            << std::to_string(Reset)
             << "m";
-        return clr;
+        return clr.str();
     }
 }
 

--- a/discordpp/colors.hh
+++ b/discordpp/colors.hh
@@ -1,0 +1,43 @@
+#ifndef DISCORDPP_COLORS_HH
+#define DISCORDPP_COLORS_HH
+
+#include <string>
+#include <sstream>
+
+namespace discordpp
+{
+
+    enum Color
+    {
+        Reset = 0,
+        Bold,
+        Faint,
+        Italic,
+        Underline,
+        Black = 30,
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Magenta,
+        Cyan,
+        White
+    };
+
+    void color(std::string str, Color color)
+    {
+        std::string clrstr = std::to_string(color);
+        std::ostringstream clr;
+
+        clr << "\033["
+            << clrstr
+            << "m"
+            << str
+            << "\033["
+            << Color.Reset
+            << "m";
+        return clr;
+    }
+}
+
+#endif//DISCORDPP_COLORS_HH

--- a/discordpp/websocketmodule.hh
+++ b/discordpp/websocketmodule.hh
@@ -64,9 +64,9 @@ namespace discordpp{
                     acknowledged = true;
                     break;
                 default:
-                    std::cout << color("Unknown opcode ", Color.Red) 
-                              << color(opcode, Color.Bold) 
-                              << color(" recieved.\n", Color.Red);
+                    std::cout << color("Unknown opcode ", Red) 
+                              << color(opcode, Bold) 
+                              << color(" recieved.\n", Red);
             }
         }
 
@@ -119,7 +119,7 @@ namespace discordpp{
                 std::cerr << "Discord Lost" << '\n';
                 close();
             }else {
-                std::cout << color("Sending Heartbeat ", Color.Green) << color(sequence_number_, Color.Bold) << ":\n";
+                std::cout << color("Sending Heartbeat ", Green) << color(sequence_number_, Bold) << ":\n";
                 sendkeepalive({{"op", 1},
                                {"d",  sequence_number_}});
                 acknowledged = false;

--- a/discordpp/websocketmodule.hh
+++ b/discordpp/websocketmodule.hh
@@ -13,6 +13,8 @@
 //#include <lib/nlohmannjson/src/json.hpp>
 #include <nlohmann/json.hpp>
 
+#include "colors.hh"
+
 namespace discordpp{
     namespace asio = boost::asio;
     using boost::system::error_code;
@@ -62,7 +64,9 @@ namespace discordpp{
                     acknowledged = true;
                     break;
                 default:
-                    std::cout << "Unknown opcode " << opcode << " recieved.\n";
+                    std::cout << color("Unknown opcode ", Color.Red) 
+                              << color(opcode, Color.Bold) 
+                              << color(" recieved.\n", Color.Red);
             }
         }
 
@@ -115,7 +119,7 @@ namespace discordpp{
                 std::cerr << "Discord Lost" << '\n';
                 close();
             }else {
-                std::cout << "Sending Heartbeat " << sequence_number_ << ":\n";
+                std::cout << color("Sending Heartbeat ", Color.Green) << color(sequence_number_, Color.Bold) << ":\n";
                 sendkeepalive({{"op", 1},
                                {"d",  sequence_number_}});
                 acknowledged = false;


### PR DESCRIPTION
Added a `Color` enum with ANSI color codes, and a `color` function that takes an `std::string` and a `Color` and returns the string colored that color. 

Usage:

```cpp
std::cout
    << color("this will be green\n", Green)
    << color("this will be red\n", Red)
    << color("there are other colors but im not gonna type them all\n", Bold);
```