### PR TITLE
Added stream-friendly colors to refactor

### DIFF
--- a/discordpp/bot.hh
+++ b/discordpp/bot.hh
@@ -12,6 +12,8 @@
 
 #include "botStruct.hh"
 
+#include "colors.hh"
+
 namespace discordpp {
     using json = nlohmann::json;
     using snowflake = uint64_t;
@@ -38,11 +40,11 @@ namespace discordpp {
     protected:
         void sendHeartbeat() {
             if(!gotACK){
-                std::cerr << "Discord Servers did not respond to heartbeat. Reconnect not implemented.\n";
+                std::cerr << clr(Red) << "Discord Servers did not respond to heartbeat. Reconnect not implemented.\n" << clr(Reset);
                 exit(1);
             }
             gotACK = false;
-            std::cout << "Sending heartbeat..." << std::endl;
+            std::cout << clr(Bold) << "Sending heartbeat...\n" << clr(Reset);
             pacemaker_ = std::make_unique<boost::asio::steady_timer>(
                     *aioc,
                     std::chrono::steady_clock::now() + *heartrate_
@@ -66,7 +68,7 @@ namespace discordpp {
                 case 0:  // Dispatch:           dispatches an event
                     sequence_ = payload["s"].get<int>();
                     if(handlers.find(payload["t"]) == handlers.end()){
-                        std::cerr << "No handlers defined for " << payload["t"] << "\n";
+                        std::cerr << clr(Yellow) << "No handlers defined for " << payload["t"] << clr(Reset) << "\n";
                     }else{
                         for(auto handler = handlers.lower_bound(payload["t"]); handler != handlers.upper_bound(payload["t"]); handler++){
                             handler->second(payload["d"]);
@@ -74,13 +76,13 @@ namespace discordpp {
                     }
                     break;
                 case 1:  // Heartbeat:          used for ping checking
-                    std::cerr << "Discord Servers requested a heartbeat, which is not implemented.\n";
+                    std::cerr << clr(Red) << "Discord Servers requested a heartbeat, which is not implemented.\n" << clr(Reset);
                     break;
                 case 7:  // Reconnect:          used to tell clients to reconnect to the gateway
-                    std::cerr << "Discord Servers requested a reconnect. Reconnect not implemented.";
+                    std::cerr << clr(Red) << "Discord Servers requested a reconnect. Reconnect not implemented." << clr(Reset);
                     exit(1);
                 case 9:  // Invalid Session:	used to notify client they have an invalid session id
-                    std::cerr << "Discord Servers notified of an invalid session ID. Reconnect not implemented.";
+                    std::cerr << clr(Red) << "Discord Servers notified of an invalid session ID. Reconnect not implemented." << clr(Red);
                     exit(1);
                 case 10: // Hello:              sent immediately after connecting, contains heartbeat and server debug information
                     heartrate_ = std::make_unique<std::chrono::milliseconds>(payload["d"]["heartbeat_interval"]);
@@ -97,11 +99,11 @@ namespace discordpp {
                     break;
                 case 11: // Heartbeat ACK:      sent immediately following a client heartbeat that was received
                     gotACK = true;
-                    std::cout << "Heartbeat Successful." << std::endl;
+                    std::cout << clr(Green) << "Heartbeat Successful.\n" << clr(Reset);
                     break;
                 default:
-                    std::cerr << "Unexpected opcode " << payload["op"] << "! Message:\n"
-                              << payload.dump(4) << '\n';
+                    std::cerr << clr(Red) << "Unexpected opcode " << payload["op"] << "! Message:\n"
+                              << payload.dump(4) << '\n' << clr(Reset);
             }
         }
     };

--- a/discordpp/botStruct.hh
+++ b/discordpp/botStruct.hh
@@ -11,6 +11,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "colors.hh"
+
 namespace discordpp {
     using json = nlohmann::json;
 
@@ -28,7 +30,7 @@ namespace discordpp {
             bool ready = true;
             for(auto module: needInit){
                 if(module.second){
-                    std::cerr << "Forgot to initialize: " << module.first << '\n';
+                    std::cerr << clr(Red) << "Forgot to initialize: " << module.first << clr(Reset) << '\n';
                     ready = false;
                 }
             }
@@ -39,9 +41,9 @@ namespace discordpp {
 
     protected:
         virtual void runctd(){
-            std::cerr << "Starting run loop" << '\n';
+            std::cerr << clr(Bold) << "Starting run loop" << clr(Reset) << '\n';
             aioc->run();
-            std::cerr << "Ending run loop" << '\n';
+            std::cerr << clr(Bold) << "Ending run loop" << clr(Reset) << '\n';
         }
 
         virtual void recievePayload(json payload) = 0;

--- a/discordpp/colors.hh
+++ b/discordpp/colors.hh
@@ -1,0 +1,53 @@
+#ifndef DISCORDPP_COLORS_HH
+#define DISCORDPP_COLORS_HH
+
+#include <string>
+#include <sstream>
+
+namespace discordpp
+{
+
+    enum Color
+    {
+        Reset = 0,
+        Bold,
+        Faint,
+        Italic,
+        Underline,
+        Black = 30,
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Magenta,
+        Cyan,
+        White
+    };
+
+    std::string clr(Color c)
+    {
+        std::ostringstream clrStr;
+        clrStr
+            << "\033["
+            << std::to_string(c)
+            << "m";
+        return clrStr.str();
+    }
+
+    std::string colorString(std::string str, Color color)
+    {
+        std::string clrstr = std::to_string(color);
+        std::ostringstream clr;
+
+        clr << "\033["
+            << clrstr
+            << "m"
+            << str
+            << "\033["
+            << std::to_string(Reset)
+            << "m";
+        return clr.str();
+    }
+}
+
+#endif//DISCORDPP_COLORS_HH


### PR DESCRIPTION
Added better colors to refactor as aido suggested.

```cpp
// usage
std::cout
    << clr(Red) << "This is red\n" << clr(Reset)
    << clr(Green) << "This is" << " green" << std::endl << clr(Reset);
// old method also still works, but this allows easier coloring of multiple
// variables and strings
```