### PR TITLE
Make log.hh definitions "inline"

### DIFF
--- a/discordpp/log.hh
+++ b/discordpp/log.hh
@@ -13,10 +13,10 @@ namespace log {
 using handleLog = std::function<void(std::ostream *)>;
 
 enum level { trace, debug, info, warning, error, fatal };
-level filter = warning;
-std::ostream *out = &std::cout;
+inline level filter = warning;
+inline std::ostream *out = &std::cout;
 
-void log(level l, handleLog msg) {
+inline void log(level l, handleLog msg) {
     if (l >= filter) {
         msg(out);
     }


### PR DESCRIPTION
The defined variables and function in log.hh were giving "multiple definition" errors when included in larger projects with multiple source-files. Adding "inline" to them allows the compiler to make sure there is only one of them and allows the project to compile.