### PR TITLE
Add missing include for msvc

### DIFF
--- a/discordpp/util.hh
+++ b/discordpp/util.hh
@@ -6,6 +6,7 @@
 
 #include "alias.hh"
 #include <random>
+#include <optional>
 
 namespace discordpp {
 namespace util {


### PR DESCRIPTION
The following commit adds a missing include required for building discordpp on msvc 2022