### PR TITLE
Code alignment for boost websocket fix and nlohmann::json newest version of library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(DISCORDPP_USE_BOOST "set ON to use Boost.Asio instead of standalone Asio"
 set(ALL_DISCORDPP_LIBRARIES "discordpp" PARENT_SCOPE)
 set(ALL_DISCORDPP_PLUGINS "" PARENT_SCOPE)
 set(ALL_DISCORDPP_INCLUDES "#include <discordpp/bot.hh>\n" PARENT_SCOPE)
+set(JSON_MultipleHeaders OFF)
 
 add_subdirectory(lib/nlohmannjson)
 
@@ -35,7 +36,9 @@ endif ()
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(${PROJECT_NAME} INTERFACE nlohmann_json::nlohmann_json fmt::fmt ${TARGET_ASIO})
+target_link_libraries(${PROJECT_NAME} INTERFACE
+        nlohmann_json::nlohmann_json
+        fmt::fmt ${TARGET_ASIO})
 
 function(CREATE_DISCORDPP_INCLUDE)
     set(DISCORDPP_INCLUDE_GENERATED ${CMAKE_BINARY_DIR}/include PARENT_SCOPE)

--- a/discordpp/bot.hh
+++ b/discordpp/bot.hh
@@ -72,8 +72,8 @@ class Bot : public virtual BotStruct {
         }
         pacemaker_->cancel();
         needACK_ = -1;
+        reconnecting_ = true;
         disconnect();
-        connect();
     }
 
   protected:

--- a/discordpp/botStruct.hh
+++ b/discordpp/botStruct.hh
@@ -228,6 +228,7 @@ class BotStruct {
     std::string token;
     bool connecting_ = false;
     bool connected_ = false;
+    bool reconnecting_ = false;
     bool ready_ = false;
 
     std::string encoding_ = "json";


### PR DESCRIPTION
As for boost websocket fix: change behaviour of reconecting process by moving connect() function call to disconnect() function in both websocket plugins

As for json version update: flag needed to be added to CMakeLists to select single header file